### PR TITLE
Makes maven 'main' profile active by default

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,9 @@
         <profile>
             <!--pure configuration - without package cc.fasttext.extra and hadoop dependencies-->
             <id>main</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
             <build>
                 <resources>
                     <resource>


### PR DESCRIPTION
Jitpack build was failing as it was not taking the maven profiles into account and getting a compilation error with hadoop.

This commits makes `main` the default maven profile