### PR TITLE
Added method to retrieve k nearest neighbours from given query vector

### DIFF
--- a/src/main/java/cc/fasttext/FastText.java
+++ b/src/main/java/cc/fasttext/FastText.java
@@ -341,6 +341,21 @@ public class FastText {
     }
 
     /**
+     * Retrieve k nearest neighbours for a given word vector.
+     * @param k          int number of expected results
+     * @param queryVec,  Vector vector to query
+     * @return {@link Multimap}
+     * @throws IllegalArgumentException if wrong input
+     */
+    public Multimap<String, Float> nn(int k, Vector queryVec) throws IllegalArgumentException {
+        Validate.notNull(queryVec, "Empty query vector");
+        Validate.isTrue(k > 0, "Not positive factor");
+        Matrix wordVectors = getPrecomputedWordVectors();
+        Set<String> banSet = new HashSet<>();
+        return Multimaps.invertFrom(findNN(wordVectors, queryVec, k, banSet), ArrayListMultimap.create());
+    }
+
+    /**
      * Original (c++) code:
      * <pre>{@code void FastText::analogies(int32_t k) {
      *  std::string word;


### PR DESCRIPTION
In some cases it is practical to retrieve k nearest neighbours not only for a given word: `nn(int k, String queryWord)` but also for a given vector: `nn(int k, Vector queryVec)`

I implemented this function so we can use it in our application, maybe this is helpful to others. Feel free to merge it.

PS: fasttext 0.2.0 was re-licensed to MIT (https://github.com/facebookresearch/fastText/commit/7842495a4d64c7a3bb4339d45d6e64321d002ed8), maybe you can reflect this in your library as well.