### PR TITLE
Fix computeSubwords method

### DIFF
--- a/src/main/java/cc/fasttext/Dictionary.java
+++ b/src/main/java/cc/fasttext/Dictionary.java
@@ -376,15 +376,15 @@ public class Dictionary {
     }
 
     private void computeSubwords(String word, List<Integer> ngrams, List<String> substrings, BiConsumer<List<Integer>, Integer> pushMethod) {
-        for (int i = 0; i < word.length(); i++) {
-            if ((word.charAt(i) & 0xC0) == 0x80) continue;
+        int len = word.length();
+        for (int i = 0, cpI; i < len; i += Character.charCount(cpI)) {
+            cpI = word.codePointAt(i);
             StringBuilder ngram = new StringBuilder();
-            for (int j = i, n = 1; j < word.length() && n <= maxn; n++) {
-                ngram.append(word.charAt(j++));
-                while (j < word.length() && (word.charAt(j) & 0xC0) == 0x80) {
-                    ngram.append(word.charAt(j++));
-                }
-                if (n >= minn && !(n == 1 && (i == 0 || j == word.length()))) {
+            for (int j = i, n = 1, cpJ; j < len && n <= maxn; n++) {
+                cpJ = word.codePointAt(j);
+                ngram.appendCodePoint(cpJ);
+                j += Character.charCount(cpJ);
+                if (n >= minn && !(n == 1 && (i == 0 || j == len))) {
                     int h = (int) (hash(ngram.toString()) % bucket.intValue());
                     pushMethod.accept(ngrams, h);
                     if (substrings != null) {

--- a/src/test/java/cc/fasttext/DictionaryTest.java
+++ b/src/test/java/cc/fasttext/DictionaryTest.java
@@ -1,6 +1,8 @@
 package cc.fasttext;
 
 import cc.fasttext.io.WordReader;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -15,6 +17,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.stream.Collectors;
 
@@ -155,4 +158,23 @@ public class DictionaryTest {
         return sb.length() == 0 ? null : sb.toString();
     }
 
+    @Test
+    public void testComputeSubwords() {
+        ImmutableMap<String, Set<String>> wordToSubwords = ImmutableMap.of(
+                "abcdef",
+                ImmutableSet.of("abcdef", "<ab", "<abc", "<abcd", "<abcde", "abc", "abcd", "abcde", "abcdef", "bcd",
+                        "bcde", "bcdef", "bcdef>", "cde", "cdef", "cdef>", "def", "def>", "ef>"
+                ),
+                // The character `𠮟` is a surrogate character. It is represented as a pair of char-type values, not a single value.
+                "父が息子を𠮟る",
+                ImmutableSet.of("父が息子を𠮟る", "<父が", "<父が息", "<父が息子", "<父が息子を", "父が息", "父が息子",
+                        "父が息子を", "父が息子を𠮟", "が息子", "が息子を", "が息子を𠮟", "が息子を𠮟る", "息子を", "息子を𠮟",
+                        "息子を𠮟る", "息子を𠮟る>", "子を𠮟", "子を𠮟る", "子を𠮟る>", "を𠮟る", "を𠮟る>", "𠮟る>"
+                )
+        );
+        for (Map.Entry<String, Set<String>> entry : wordToSubwords.entrySet()) {
+            Set<String> actualSubwords = dictionary.getSubwordsMap(entry.getKey()).keySet();
+            Assert.assertEquals(entry.getValue(), actualSubwords);
+        }
+    }
 }


### PR DESCRIPTION
According to [the link](https://stackoverflow.com/questions/3911536/utf-8-unicode-whats-with-0xc0-and-0x80/3911566#3911566), the Unicode check `(c & 0xC0) == 0x80` is only applied if strings are encoded in UTF-8. This PR fixes the character extraction from strings encoded in UTF-16.